### PR TITLE
レースコンディションの対応をUI操作の制限から更新関数の修正に変更

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ function App() {
     targets,
     selectedCategoryIndex,
     yearList,
-    isDrawing,
     onChangeDemographics,
     onChangeCategory
   } = usePopulationData();
@@ -19,11 +18,7 @@ function App() {
   return (
     <div className="App">
       <Title />
-      <PrefectureCheckboxes
-        prefectures={prefectures}
-        onChange={onChangeDemographics}
-        isDrawing={isDrawing}
-      />
+      <PrefectureCheckboxes prefectures={prefectures} onChange={onChangeDemographics} />
       {categories && (
         <DemographicsRadioButtons
           categories={categories}

--- a/src/components/PrefectureCheckboxes.tsx
+++ b/src/components/PrefectureCheckboxes.tsx
@@ -5,33 +5,24 @@ import { Prefecture } from "../types/types";
 type typePrefectures = {
   prefectures: Prefecture[];
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
-  isDrawing: boolean;
 };
 
-export const PrefectureCheckboxes: React.FC<typePrefectures> = memo(
-  ({ prefectures, onChange, isDrawing }) => {
-    return (
-      <>
-        <h2>都道府県</h2>
-        <div className="prefectureCheckboxes">
-          {prefectures &&
-            prefectures.map((prefecture) => {
-              const id = `prefcode-${prefecture.prefCode}`;
-              return (
-                <label htmlFor={id} key={prefecture.prefCode}>
-                  {prefecture.prefName}
-                  <input
-                    id={id}
-                    type="checkbox"
-                    value={prefecture.prefCode}
-                    onChange={onChange}
-                    disabled={isDrawing}
-                  />
-                </label>
-              );
-            })}
-        </div>
-      </>
-    );
-  }
-);
+export const PrefectureCheckboxes: React.FC<typePrefectures> = memo(({ prefectures, onChange }) => {
+  return (
+    <>
+      <h2>都道府県</h2>
+      <div className="prefectureCheckboxes">
+        {prefectures &&
+          prefectures.map((prefecture) => {
+            const id = `prefcode-${prefecture.prefCode}`;
+            return (
+              <label htmlFor={id} key={prefecture.prefCode}>
+                {prefecture.prefName}
+                <input id={id} type="checkbox" value={prefecture.prefCode} onChange={onChange} />
+              </label>
+            );
+          })}
+      </div>
+    </>
+  );
+});

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -1,5 +1,6 @@
 import React, { memo } from "react";
 
 export const Title = memo(() => {
+  console.log("Title");
   return <h1>ゆめみ課題</h1>;
 });

--- a/src/hooks/usePopulationData.ts
+++ b/src/hooks/usePopulationData.ts
@@ -8,7 +8,6 @@ export const usePopulationData = () => {
   const [targets, setTargets] = useState<GraphDemographicsData[]>([]);
   const [selectedCategoryIndex, SetselectedCategoryIndex] = useState(0);
   const [yearList, setYearList] = useState<number[]>([]);
-  const [isDrawing, setIsDrawing] = useState(false);
 
   useEffect(() => {
     // 初期描画用のデータ取得のため、引数prefCodeは1とする
@@ -33,34 +32,28 @@ export const usePopulationData = () => {
       .catch((err) => console.log(err));
   }, []);
 
-  const onChangeDemographics = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
-      try {
-        setIsDrawing(true);
-        const prefCode = Number(e.target.value);
-        if (targets.find((target) => prefCode === target.prefCode)) {
-          const filteredTargets = targets.filter(
-            (demographics) => demographics.prefCode !== prefCode
-          );
-          setTargets(filteredTargets);
-        } else {
-          const demographicsData = await getDemographicsData(prefCode);
+  const onChangeDemographics = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    try {
+      const prefCode = Number(e.target.value);
+      if (targets.find((target) => prefCode === target.prefCode)) {
+        setTargets((prevTargets) =>
+          prevTargets.filter((demographics) => demographics.prefCode !== prefCode)
+        );
+      } else {
+        const demographicsData = await getDemographicsData(prefCode);
 
-          const newTargets = {
-            demographicsData: demographicsData.data,
-            prefCode: prefCode
-          } as GraphDemographicsData;
-          setTargets([...targets, newTargets]);
-        }
-        setIsDrawing(false);
-      } catch (error: unknown) {
-        if (error instanceof Error) {
-          console.error(error.message);
-        }
+        const newTargets = {
+          demographicsData: demographicsData.data,
+          prefCode: prefCode
+        } as GraphDemographicsData;
+        setTargets((prevTargets) => [...prevTargets, newTargets]);
       }
-    },
-    [targets]
-  );
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error(error.message);
+      }
+    }
+  }, []);
 
   const onChangeCategory = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const categoryIndex = Number(e.target.value);
@@ -73,7 +66,6 @@ export const usePopulationData = () => {
     targets,
     selectedCategoryIndex,
     yearList,
-    isDrawing,
     onChangeDemographics,
     onChangeCategory
   };


### PR DESCRIPTION
## 概要
### 変更の目的
前回対応でチェックボックスで選択後、一時的にdisabledとして連続した処理を防いでいたが、更新関数を修正することでこれを根本的に解決した。

### 変更内容
状態として定義したisDrawingを削除、更新関数を修正
元のコード
`setTargets([...prevTargets, newTargets]);`
修正済コード
`setTargets((prevTargets) => [...prevTargets, newTargets]);`